### PR TITLE
hw/#3 3차 세미나 실습 과제

### DIFF
--- a/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
+++ b/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import opt.sopt.practice.common.dto.ErrorMessage;
 import opt.sopt.practice.common.dto.ErrorResponse;
 import opt.sopt.practice.exception.NotFoundException;
+import opt.sopt.practice.exception.UnauthorizedActionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -22,6 +23,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(UnauthorizedActionException.class)
+    protected ResponseEntity<ErrorResponse> handleUnauthorizedActionException(UnauthorizedActionException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(ErrorResponse.of(e.getErrorMessage()));
     }
 

--- a/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
+++ b/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorMessage {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
-    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다.");
+    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
+    BLOG_NOT_OWNED_BY_USER(HttpStatus.FORBIDDEN.value(), "이 블로그에 대한 권한이 없습니다."),
+    POST_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
+    ;
     private final int status;
     private final String message;
 }

--- a/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
+++ b/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorMessage {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
-    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
     BLOG_NOT_OWNED_BY_USER(HttpStatus.FORBIDDEN.value(), "이 블로그에 대한 권한이 없습니다."),
-    POST_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
     ;
     private final int status;
     private final String message;

--- a/practice/src/main/java/opt/sopt/practice/common/dto/SuccessMessage.java
+++ b/practice/src/main/java/opt/sopt/practice/common/dto/SuccessMessage.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessMessage {
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다."),
+    POST_CREATE_SUCCESS(HttpStatus.CREATED.value(), "글 생성이 완료되었습니다."),
+    POST_GET_SUCCESS(HttpStatus.OK.value(), "게시글 조회가 완료되었습니다"),
     ;
     private final int status;
     private final String message;

--- a/practice/src/main/java/opt/sopt/practice/common/dto/SuccessStatusResponse.java
+++ b/practice/src/main/java/opt/sopt/practice/common/dto/SuccessStatusResponse.java
@@ -1,8 +1,16 @@
 package opt.sopt.practice.common.dto;
 
 
-public record SuccessStatusResponse(int status, String message) {
-    public static SuccessStatusResponse of(SuccessMessage successMessage) {
-        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage());
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Optional;
+
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+public record SuccessStatusResponse<T>(int status, String message, Optional<T> data) {
+    public static <T> SuccessStatusResponse<T> of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage(), Optional.empty());
+    }
+
+    public static <T> SuccessStatusResponse<T> of(SuccessMessage successMessage, T data) {
+        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage(), Optional.of(data));
     }
 }

--- a/practice/src/main/java/opt/sopt/practice/controller/PostController.java
+++ b/practice/src/main/java/opt/sopt/practice/controller/PostController.java
@@ -1,0 +1,51 @@
+package opt.sopt.practice.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import opt.sopt.practice.common.dto.SuccessMessage;
+import opt.sopt.practice.common.dto.SuccessStatusResponse;
+import opt.sopt.practice.service.PostService;
+import opt.sopt.practice.service.dto.PostCreateRequest;
+import opt.sopt.practice.service.dto.PostFindAllResponse;
+import opt.sopt.practice.service.dto.PostFindResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping("/post")
+    public ResponseEntity<SuccessStatusResponse> createPost(@RequestHeader Long memberId,
+                                                            @RequestHeader Long blogId,
+                                                            @Valid @RequestBody PostCreateRequest postCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", postService.create(memberId, blogId, postCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.POST_CREATE_SUCCESS));
+    }
+
+    //게시글 id로 게시글 하나 조회
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<SuccessStatusResponse<PostFindResponse>> getPostById(@PathVariable Long postId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.POST_GET_SUCCESS, postService.findPostById(postId)));
+    }
+
+
+    //blogId가 가리키는 블로그에 있는 모든 게시글 조회
+    @GetMapping("post/all/{blogId}")
+    public ResponseEntity<SuccessStatusResponse<List<PostFindAllResponse>>> getPostByBlogId(@PathVariable Long blogId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.POST_GET_SUCCESS, postService.findPostByBlogId(blogId)));
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/domain/Post.java
+++ b/practice/src/main/java/opt/sopt/practice/domain/Post.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import opt.sopt.practice.service.dto.PostCreateRequest;
 
 @Entity
 @Getter
@@ -21,4 +22,14 @@ public class Post extends BaseTImeEntity {
     private String content;
     @ManyToOne(fetch = FetchType.LAZY)
     private Blog blog;
+
+    private Post(Blog blog, String name, String content) {
+        this.name = name;
+        this.content = content;
+        this.blog = blog;
+    }
+
+    public static Post create(Blog blog, PostCreateRequest postCreateRequest) {
+        return new Post(blog, postCreateRequest.name(), postCreateRequest.content());
+    }
 }

--- a/practice/src/main/java/opt/sopt/practice/exception/UnauthorizedActionException.java
+++ b/practice/src/main/java/opt/sopt/practice/exception/UnauthorizedActionException.java
@@ -1,0 +1,9 @@
+package opt.sopt.practice.exception;
+
+import opt.sopt.practice.common.dto.ErrorMessage;
+
+public class UnauthorizedActionException extends BusinessException {
+    public UnauthorizedActionException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/repository/PostRepository.java
+++ b/practice/src/main/java/opt/sopt/practice/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package opt.sopt.practice.repository;
+
+import java.util.List;
+import opt.sopt.practice.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllByBlog_Id(Long blogId); // Blog 엔티티의 id로 Post 목록 검색
+}

--- a/practice/src/main/java/opt/sopt/practice/service/PostService.java
+++ b/practice/src/main/java/opt/sopt/practice/service/PostService.java
@@ -1,0 +1,50 @@
+package opt.sopt.practice.service;
+
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import opt.sopt.practice.common.dto.ErrorMessage;
+import opt.sopt.practice.domain.Blog;
+import opt.sopt.practice.domain.Member;
+import opt.sopt.practice.domain.Post;
+import opt.sopt.practice.exception.NotFoundException;
+import opt.sopt.practice.exception.UnauthorizedActionException;
+import opt.sopt.practice.repository.PostRepository;
+import opt.sopt.practice.service.dto.MemberFindAllDto;
+import opt.sopt.practice.service.dto.PostCreateRequest;
+import opt.sopt.practice.service.dto.PostFindAllResponse;
+import opt.sopt.practice.service.dto.PostFindResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+    private final BlogService blogService;
+    private final MemberService memberService;
+
+    @Transactional
+    public String create(Long memberId, Long blogId, PostCreateRequest postCreateRequest) {
+        Member member = memberService.findById(memberId);
+        Blog blog = blogService.findBlogById(blogId);
+
+        //사용자가 해당 블로그를 소유하고 있는지 확인
+        if (member != blog.getMember()) {
+            throw new UnauthorizedActionException(ErrorMessage.BLOG_NOT_OWNED_BY_USER);
+        }
+
+        Post post = postRepository.save(Post.create(blog, postCreateRequest));
+        return post.getId().toString();
+    }
+
+    public PostFindResponse findPostById(Long postId) {
+        return PostFindResponse.of(postRepository.findById(postId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.POST_NOT_FOUND)
+        ));
+    }
+
+    public List<PostFindAllResponse> findPostByBlogId(Long blogId) {
+        blogService.findBlogById(blogId); //blogId에 해당하는 블로그가 없을 경우 오류 출력을 위함
+        return PostFindAllResponse.findAll(postRepository.findAllByBlog_Id(blogId));
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/service/dto/PostCreateRequest.java
+++ b/practice/src/main/java/opt/sopt/practice/service/dto/PostCreateRequest.java
@@ -3,8 +3,8 @@ package opt.sopt.practice.service.dto;
 import jakarta.validation.constraints.Size;
 
 public record PostCreateRequest(
-        @Size(min = 1, max = 20, message = "게시글 제목이 최대 글자 수(10자)를 초과했습니다.")
+        @Size(min = 1, max = 20, message = "게시글 제목은 최소 1자 최대 20자여야 합니다.")
         String name,
-        @Size(min = 1, max = 200, message = "게시글 본문이 최대 글자 수(200자)를 초과했습니다.")
+        @Size(min = 1, max = 200, message = "게시글 내용은 최소 1자 최대 200자여야 합니다.")
         String content) {
 }

--- a/practice/src/main/java/opt/sopt/practice/service/dto/PostCreateRequest.java
+++ b/practice/src/main/java/opt/sopt/practice/service/dto/PostCreateRequest.java
@@ -1,0 +1,10 @@
+package opt.sopt.practice.service.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record PostCreateRequest(
+        @Size(min = 1, max = 20, message = "게시글 제목이 최대 글자 수(10자)를 초과했습니다.")
+        String name,
+        @Size(min = 1, max = 200, message = "게시글 본문이 최대 글자 수(200자)를 초과했습니다.")
+        String content) {
+}

--- a/practice/src/main/java/opt/sopt/practice/service/dto/PostFindAllResponse.java
+++ b/practice/src/main/java/opt/sopt/practice/service/dto/PostFindAllResponse.java
@@ -1,0 +1,16 @@
+package opt.sopt.practice.service.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import opt.sopt.practice.domain.Post;
+
+public record PostFindAllResponse(String name, String content) {
+    public static List<PostFindAllResponse> findAll(List<Post> posts) {
+        List<PostFindAllResponse> list = posts.stream().map(PostFindAllResponse::of).collect(Collectors.toList());
+        return list;
+    }
+
+    public static PostFindAllResponse of(Post post) {
+        return new PostFindAllResponse(post.getName(), post.getContent());
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/service/dto/PostFindResponse.java
+++ b/practice/src/main/java/opt/sopt/practice/service/dto/PostFindResponse.java
@@ -1,0 +1,9 @@
+package opt.sopt.practice.service.dto;
+
+import opt.sopt.practice.domain.Post;
+
+public record PostFindResponse(String name, String content) {
+    public static PostFindResponse of(Post post) {
+        return new PostFindResponse(post.getName(), post.getContent());
+    }
+}


### PR DESCRIPTION
- closes #7 
## 이 주의 과제 :closed_book:

<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
### 블로그에 글을 작성하는 POST api

#### PostCreateRequest
https://github.com/NOW-SOPT-SERVER/elive7/blob/2e329fef42895df646217e98b9191d6f297e7534/practice/src/main/java/opt/sopt/practice/service/dto/PostCreateRequest.java#L5-L10
게시글 POST시 POST 되는 객체에 대해 Request Body Validation이 이루어질 수 있도록 위와 같이 작성해주었습니다.

#### PostController
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/controller/PostController.java#L28-L35
memberId와 blogId, postCreateRequest를 이용해 post 생성을 시도해 성공시 header location에 postId이 포함되고 body에는 POST_CREATE_SUCCESS 응답이 가도록 작성해주었습니다.

#### PostService
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/service/PostService.java#L26-L38
먼저 주어진 memberId에 해당하는 member와 주어진 blogId에 해당하는 블로그의 주인 member를 비교해 사용자가 해당 블로그를 소유하고 있지 않다면, UnauthorizedActionException를 발생시켜주었습니다. 이를 통해 사용자가 해당 블로그를 소유하고 있을 때만, post를 저장하고, 저장된 post의 id를 return하는 코드를 작성해주었습니다.

#### UnauthorizedActionException
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/exception/UnauthorizedActionException.java#L5-L9

#### ErrorMessage
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java#L12

#### GlobalExceptionHandler
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java#L29-L35

#### SuccessMessage
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/common/dto/SuccessMessage.java#L11

게시글 작성 api에 필요한 에러 처리 코드나 성공 메세지 코드를 위와 같이 작성해주었습니다.

### 블로그 글을 조회하는 GET api
### 1. 게시글 id로 해당 게시글을 조회하는 GET api 

#### PostFindResponse
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/service/dto/PostFindResponse.java#L5-L9
응답에 post의 name과 content를 포함시키도록 다음과 같이 작성해주었습니다.

#### SuccessStatusResponse
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/common/dto/SuccessStatusResponse.java#L7-L16
해당 api는 응답에 data를 포함할 수 있어야 합니다. 따라서 SuccessStatusResponse를 위와 같이 변경해주었습니다. Optional 키워드로 data가 비어 있을 수 있도록 만들어주었으며, successMessage만을 받아 data로는 Optional.empty()를 보내주는 생성자와 successMessage와 data를 모두 받아 실제 data를 넘겨주는 생성자 2개를 작성하였습니다. 또한, `@JsonInclude(JsonInclude.Include.NON_ABSENT)` 를 사용하여 data가 Optional.empty()인 경우에는 응답 json에 data 필드가 포함되지 않도록 작성해주었습니다.

#### PostController
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/controller/PostController.java#L37-L42
앞서 변경한 SuccessStatusResponse를 이용하여, 성공시 응답에 SuccessMessage와 PostFindResponse 형태의 data가 포함되도록 작성해주었습니다.

#### PostService
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/service/PostService.java#L40-L44
postId에 해당하는 post를 찾아 PostFindResponse 형태로 post의 정보를 return합니다. 만약, postId에 해당하는 post가 없다면 POST_NOT_FOUND라는 NotFoundException를 발생시킵니다.

#### ErrorMessage
https://github.com/NOW-SOPT-SERVER/elive7/blob/2e329fef42895df646217e98b9191d6f297e7534/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java#L13


#### SuccessMessage
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/common/dto/SuccessMessage.java#L12

게시글id로 게시글을 조회하는 api에 필요한 에러 메세지 코드나 성공 메세지 코드를 위와 같이 작성해주었습니다.

### 2. 블로그 id로 해당 블로그에 포함된 모든 게시글을 조회하는 GET api 
#### PostFindAllResponse
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/service/dto/PostFindAllResponse.java#L7-L16

게시글 list를 반환할 수 있도록 PostFindAllResponse를 다음과 같이 작성해주었습니다.

#### PostController
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/controller/PostController.java#L45-L51
앞 api와 마찬가지로 SuccessStatusResponse를 이용하여, 성공시 응답에 SuccessMessage와 List<PostFindAllResponse> 형태의 data가 포함되도록 작성해주었습니다.

#### PostRepository
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/repository/PostRepository.java#L7-L9
 blog의 id가 주어졌을 때, 해당 블로그에 속한 게시글을 모두 찾는 함수를 추가해 주었습니다.

#### PostService
https://github.com/NOW-SOPT-SERVER/elive7/blob/56ef0958ff93750b7bd974f44ed6664c292d1f99/practice/src/main/java/opt/sopt/practice/service/PostService.java#L46-L49
PostRepository에서 정의한 findAllByBlog_Id를 이용해서 해당 블로그에 해당하는 post들의 정보를 리턴해주었습니다. 이 때 주어진 blogId에 해당하는 블로그가 없을 경우 BLOG_NOT_FOUND 오류를 출력하기 위해 `blogService.findBlogById(blogId)`를 사용했습니다.

## 요구사항 분석 :orange_book:

<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- localhost:8080/api/v1/post로 header에 memberId와 blogId를 담고, body에 post의 name, content를 json 형태로 보내면 해당 post를 생성할 수 있도록 코드를 작성했습니다.
- localhost:8080/api/v1/post/:postId 로 get 요청을 보내면 해당 게시글의 내용을 리턴하도록 코드를 작성했습니다.
- localhost:8080/api/v1/post/all/:blogId로 get 요청을 보내면 해당 블로그의 모든 게시글 내용을 리턴하도록 코드를 작성했습니다
(더 자세한 사항은 api 명세서를 참고해주세요.)

## 구현 고민 사항 :green_book:
<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->
- 블로그를 소유하지 않는 사용자가 해당 블로그에 글을 작성하려고 할 때, 발생시킬 에러 코드로 Unauthorized와 Forbidden를 고민했는데, 해당 사용자가 존재하지만, 블로그에 글을 쓸 권한이 없어 문제가 발생하는 것이므로 Forbidden을 선택했습니다.
- 기존에는 SuccessStatusResponse에 status와 message만 있었지만 게시글 조회 api 등에서 data도 추가로 필요로 합니다. 따라서 optional 필드로 data를 추가하여, 기존에 data없이 동작하던 api도 수정없이 동작하되, 필요한 경우 data도 추가로 json에 넘겨줄 수 있도록 코드를 작성하였습니다. (제네릭 타입 파리미터를 생략하는 기존 코드의 경우 컴파일러가 자동으로 타입을 유추해줍니다. 즉 data가 필요하지 않을 때, `SuccessStatusResponse`로 사용해도 컴파일러가 자동으로 `SuccessStatusResponse<Void>`를 생성해줍니다.)



## 질문있어요! :blue_book:

<!-- 구현하면서 코드리뷰조원이나 명예 OB 분들께 하고 싶었던 질문이 있다면 (필요시)코드 좌표와 함께 **자세히** 적어주세요! -->
-  dto 클래스 이름을 ~dto로 짓기도 하고 ~Request /~Response로 짓기도 하는데 이는 그냥 코드 스타일 차이인지, 둘의 의미가 다른 것인지 궁금합니다.
- 현재 data가 null이라면 응답 json에 data라는 항목이 포함되지 않도록 `@JsonInclude(JsonInclude.Include.NON_ABSENT)`을 사용해주었습니다.
실제 코드에서는 1. data가 null인 것을 그대로 응답 json에 노출하는 방법,  2. data 필드가 null인 경우 아예 응답 json에 포함시키지 않는 방법 둘 중 어느 것을 선호하는지 궁금합니다.
1. 
```json
{
    "status": 201,
    "message": "글 생성이 완료되었습니다.",
    "data": null
}
```
2.
```json
{
    "status": 201,
    "message": "글 생성이 완료되었습니다."
}
```



## API 명세서 :notebook_with_decorative_cover:
https://regular-cow-aa9.notion.site/3-API-90446389a7974a7ab19f480e9ed98e81?pvs=4
