### PR TITLE
Hw/#4 6주차 세미나 실습 과제

### DIFF
--- a/practice/build.gradle
+++ b/practice/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     //Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 
     //Multipart file
     implementation("software.amazon.awssdk:bom:2.21.0")

--- a/practice/src/main/java/opt/sopt/practice/auth/SecurityConfig.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member"};
+    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member", "/api/v1/token/refresh"};
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/controller/TokenController.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/controller/TokenController.java
@@ -8,6 +8,7 @@ import opt.sopt.practice.auth.rds.service.dto.RefreshTokenRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +20,7 @@ public class TokenController {
 
     @PostMapping("/token/refresh")
     public ResponseEntity<AccessTokenResponse> refreshAccessToken(
-            @RequestBody RefreshTokenRequest refreshTokenRequest) {
-        String refreshToken = refreshTokenRequest.refreshToken();
+            @RequestHeader String refreshToken) {
         return ResponseEntity.ok(tokenService.refreshAccessToken(refreshToken));
     }
 }

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/controller/TokenController.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/controller/TokenController.java
@@ -1,0 +1,26 @@
+package opt.sopt.practice.auth.rds.controller;
+
+import lombok.RequiredArgsConstructor;
+import opt.sopt.practice.auth.rds.domain.Token;
+import opt.sopt.practice.auth.rds.service.TokenService;
+import opt.sopt.practice.auth.rds.service.dto.AccessTokenResponse;
+import opt.sopt.practice.auth.rds.service.dto.RefreshTokenRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<AccessTokenResponse> refreshAccessToken(
+            @RequestBody RefreshTokenRequest refreshTokenRequest) {
+        String refreshToken = refreshTokenRequest.refreshToken();
+        return ResponseEntity.ok(tokenService.refreshAccessToken(refreshToken));
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/domain/Token.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/domain/Token.java
@@ -1,0 +1,31 @@
+package opt.sopt.practice.auth.rds.domain;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Generated;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "", timeToLive = 60 * 60 * 24 * 1000L * 14)
+@AllArgsConstructor
+@Getter
+@Builder
+public class Token {
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    public static Token of(
+            final Long id,
+            final String refreshToken
+    ) {
+        return Token.builder()
+                .id(id)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/repository/TokenRepository.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/repository/TokenRepository.java
@@ -1,0 +1,11 @@
+package opt.sopt.practice.auth.rds.repository;
+
+import java.util.Optional;
+import opt.sopt.practice.auth.rds.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenRepository extends CrudRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(final String refreshToken);
+
+    Optional<Token> findById(final Long id);
+}

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/service/TokenService.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/service/TokenService.java
@@ -1,0 +1,32 @@
+package opt.sopt.practice.auth.rds.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import opt.sopt.practice.auth.UserAuthentication;
+import opt.sopt.practice.auth.rds.domain.Token;
+import opt.sopt.practice.auth.rds.repository.TokenRepository;
+import opt.sopt.practice.auth.rds.service.dto.AccessTokenResponse;
+import opt.sopt.practice.common.dto.ErrorMessage;
+import opt.sopt.practice.common.jwt.JwtTokenProvider;
+import opt.sopt.practice.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final TokenRepository tokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public Token findByRefreshToken(String refreshToken) {
+        return tokenRepository.findByRefreshToken(refreshToken).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.REFRESH_TOKEN_NOT_FOUND)
+        );
+    }
+
+    public AccessTokenResponse refreshAccessToken(String refreshToken) {
+        Token token = findByRefreshToken(refreshToken);
+        Long memberId = token.getId();
+        String accessToken = jwtTokenProvider.issueAccessToken(UserAuthentication.createUserAuthentication(memberId));
+        return AccessTokenResponse.of(accessToken);
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/service/dto/AccessTokenResponse.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/service/dto/AccessTokenResponse.java
@@ -1,0 +1,7 @@
+package opt.sopt.practice.auth.rds.service.dto;
+
+public record AccessTokenResponse(String accessToken) {
+    public static AccessTokenResponse of(String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/auth/rds/service/dto/RefreshTokenRequest.java
+++ b/practice/src/main/java/opt/sopt/practice/auth/rds/service/dto/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package opt.sopt.practice.auth.rds.service.dto;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
+++ b/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.Objects;
 import opt.sopt.practice.common.dto.ErrorMessage;
 import opt.sopt.practice.common.dto.ErrorResponse;
+import opt.sopt.practice.exception.AccessTokenExpiredException;
 import opt.sopt.practice.exception.NotFoundException;
 import opt.sopt.practice.exception.UnauthorizedActionException;
 import opt.sopt.practice.exception.UnauthorizedException;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -19,6 +21,13 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
                 Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
+                e.getMessage()));
     }
 
     @ExceptionHandler(NotFoundException.class)
@@ -35,6 +44,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     protected ResponseEntity<ErrorResponse> handlerUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
+    }
+
+    @ExceptionHandler(AccessTokenExpiredException.class)
+    protected ResponseEntity<ErrorResponse> handlerAccessTokenExpiredException(AccessTokenExpiredException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
     }

--- a/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
+++ b/practice/src/main/java/opt/sopt/practice/common/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
-            MethodArgumentNotValidException e) {
+            MethodArgumentTypeMismatchException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
                 e.getMessage()));
     }

--- a/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
+++ b/practice/src/main/java/opt/sopt/practice/common/dto/ErrorMessage.java
@@ -11,9 +11,9 @@ public enum ErrorMessage {
     BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
     BLOG_NOT_OWNED_BY_USER(HttpStatus.FORBIDDEN.value(), "이 블로그에 대한 권한이 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
-
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 refresh token에 대한 정보를 찾을 수 없습니다. 다시 로그인해주세요"),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
-    ;
+    JWT_ACCESS_TOKEN_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "access token이 만료되었습니다.");
     private final int status;
     private final String message;
 }

--- a/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java
+++ b/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java
@@ -26,7 +26,7 @@ public class JwtTokenProvider {
     private static final String ROLES = "roles";
 
     private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 5 * 60 * 1000L; // 5 minutes
-    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 1000L; // 14 days
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14; // 14 days
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;

--- a/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java
+++ b/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java
@@ -9,8 +9,11 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import opt.sopt.practice.auth.UserAuthentication;
+import opt.sopt.practice.auth.rds.domain.Token;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -20,19 +23,41 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
     private static final String USER_ID = "userId";
+    private static final String ROLES = "roles";
 
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 5 * 60 * 1000L; // 5 minutes
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 1000L; // 14 days
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;
 
 
     public String issueAccessToken(final Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+        return generateAccessToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    public String issueRefreshToken(final Authentication authentication) {
+        return generateRefreshToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
 
-    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+    public String generateAccessToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        claims.put(USER_ID, authentication.getPrincipal());
+        claims.put(ROLES, authentication.getCredentials()); //accessToken에 역할을 추가적으로 부여
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    public String generateRefreshToken(Authentication authentication, Long tokenExpirationTime) {
         final Date now = new Date();
         final Claims claims = Jwts.claims()
                 .setIssuedAt(now)

--- a/practice/src/main/java/opt/sopt/practice/exception/AccessTokenExpiredException.java
+++ b/practice/src/main/java/opt/sopt/practice/exception/AccessTokenExpiredException.java
@@ -1,0 +1,9 @@
+package opt.sopt.practice.exception;
+
+import opt.sopt.practice.common.dto.ErrorMessage;
+
+public class AccessTokenExpiredException extends BusinessException {
+    public AccessTokenExpiredException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/practice/src/main/java/opt/sopt/practice/service/dto/UserJoinResponse.java
+++ b/practice/src/main/java/opt/sopt/practice/service/dto/UserJoinResponse.java
@@ -2,14 +2,17 @@ package opt.sopt.practice.service.dto;
 
 public record UserJoinResponse(
         String accessToken,
+
+        String refreshToken,
         String userId
 ) {
 
     public static UserJoinResponse of(
             String accessToken,
+            String refreshToken,
             String userId
     ) {
-        return new UserJoinResponse(accessToken, userId);
+        return new UserJoinResponse(accessToken, refreshToken, userId);
     }
 }
 


### PR DESCRIPTION
- closes #11  
## 이 주의 과제 :closed_book:
<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
### 회원 가입시 access token과 함꼐 refresh token 반환하는 로직
#### Token
https://github.com/NOW-SOPT-SERVER/elive7/blob/a7a0450911bab292d0c4b7f3bb28f819b0551a11/practice/src/main/java/opt/sopt/practice/auth/rds/domain/Token.java#L11-L31
refreshToken을 redis에 저장하기 위해, token 클래스를 정의해두었습니다.

#### ‎TokenRepository
https://github.com/NOW-SOPT-SERVER/elive7/blob/a7a0450911bab292d0c4b7f3bb28f819b0551a11/practice/src/main/java/opt/sopt/practice/auth/rds/repository/TokenRepository.java#L7-L11
CrudRepository를 상속받아 토큰을 저장하기 위한 레포지토리를 만들어주었습니다.

#### ‎JwtTokenProvider
https://github.com/NOW-SOPT-SERVER/elive7/blob/a7a0450911bab292d0c4b7f3bb28f819b0551a11/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java#L39-L41
https://github.com/NOW-SOPT-SERVER/elive7/blob/a7a0450911bab292d0c4b7f3bb28f819b0551a11/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java#L60-L73
JwtTokenProvider에 refreshToken을 생성하고, authentication에 따라 발행하는 로직을 작성해주었습니다. 

https://github.com/NOW-SOPT-SERVER/elive7/blob/110788f2da4a96afe806f4e638c74122bfc9273c/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java#L28-L29
이때 accessToken과 refreshToken의 만료 시간을 각각 5분과 14일로 설정하여, accessToken이 만료되더라도 refreshToken으로 새 accessToken을 받아올 수 있도록 하였습니다.

#### UserJoinResponse과 MemberService
https://github.com/NOW-SOPT-SERVER/elive7/blob/110788f2da4a96afe806f4e638c74122bfc9273c/practice/src/main/java/opt/sopt/practice/service/dto/UserJoinResponse.java#L3-L17
https://github.com/NOW-SOPT-SERVER/elive7/blob/110788f2da4a96afe806f4e638c74122bfc9273c/practice/src/main/java/opt/sopt/practice/service/MemberService.java#L28-L48
UserJoinResponse에 refreshToken을 추가하고, MemberService에서도 회원가입시 Refresh Token을 생성 및 레포지토리에 저장한 후 응답으로도 Refresh Token를 돌려주는 로직을 추가해주었습니다.

### access token 만료시 메세지 반환하는 로직
#### ‎JwtAuthenticationFilter
https://github.com/NOW-SOPT-SERVER/elive7/blob/110788f2da4a96afe806f4e638c74122bfc9273c/practice/src/main/java/opt/sopt/practice/auth/filter/JwtAuthenticationFilter.java#L45-L54
JWT_ACCESS_TOKEN_EXPIRED_EXCEPTION 이라는 에러 메세지를 만든 후, JwtAuthenticationFilter에서 accessToken이 이미 만료되었다면, JWT_ACCESS_TOKEN_EXPIRED_EXCEPTION에 대한 응답을 리턴할 수 있도록 다음과 같은 코드를 작성해주었습니다.

### refresh token으로 access token 반환하는 로직
#### ‎TokenController
https://github.com/NOW-SOPT-SERVER/elive7/blob/4b2d7f4a234689001150218e7d114999753e3493/practice/src/main/java/opt/sopt/practice/auth/rds/controller/TokenController.java#L15-L26
헤더에 refreshToken을 담아서 특정 url로 요청을 보내면, accessToken을 재발급 해주는 controller를 작성했습니다.

#### ‎TokenService
https://github.com/NOW-SOPT-SERVER/elive7/blob/4b2d7f4a234689001150218e7d114999753e3493/practice/src/main/java/opt/sopt/practice/auth/rds/service/TokenService.java#L14-L32
인자로 전달된 refreshToken을 repository에서 찾아서 해당 refreshToken이 존재한다면, refreshToken의 memberId 정보를 가지고 새롭게 accessToken을 발급해주는 로직을 작성해주었습니다. refreshToken이 존재하지 않는다면 그에 맞게 REFRESH_TOKEN_NOT_FOUND라는 오류를 발생시켜 주었습니다.

#### SecurityConfig
https://github.com/NOW-SOPT-SERVER/elive7/blob/4b2d7f4a234689001150218e7d114999753e3493/practice/src/main/java/opt/sopt/practice/auth/SecurityConfig.java#L26
또한, SecurityConfig에서 accessToken을 재발급하는 url를 whitelist로 지정해두었습니다.

## 요구사항 분석 :orange_book:
<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- localhost:8080/api/v1/member로 회원가입을 시도할 시, refresh Token도 함께 반환되도록 코드를 작성했습니다.
- 요청이 들어왔을 때, access token이 만료되었다면 그에 해당하는 error를 반환할 수 있도록 작성해주었습니다.
- localhost:8080/api/v1/token/refresh로  헤더에 refreshToken을 담아서 보내면 재발급된 accessToken을 리턴하도록 코드를 작성해주었습니다.

## 구현 고민 사항 :green_book:
<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->
- Refresh Token과 Access Token은 서로 다른 목적으로 사용되므로 일부 차이점을 두는 것이 좋습니다. Refresh Token은 사용자 인증을 갱신하는 데 사용되며, Access Token은 실제 리소스에 접근하는 데 사용됩니다. 따라서 Refresh Token은 최소한의 정보만 포함하고, Access Token은 필요한 클레임을 포함하는 것이 일반적입니다. 이에 따라 Access Token에는 사용자의 식별자와 권한 정보를 포함하고, Refresh Token은 사용자의 식별자만 포함하도록 코드를 작성했습니다.
https://github.com/NOW-SOPT-SERVER/elive7/blob/4b2d7f4a234689001150218e7d114999753e3493/practice/src/main/java/opt/sopt/practice/common/jwt/JwtTokenProvider.java#L44-L73
## 질문있어요! :blue_book:

<!-- 구현하면서 코드리뷰조원이나 명예 OB 분들께 하고 싶었던 질문이 있다면 (필요시)코드 좌표와 함께 **자세히** 적어주세요! -->
- 현재 access Token이 만료되었을 경우, 그에 해당하는 error를 반환할 수 있도록 작성하는 코드를 더 깔끔하게 할 수 있는 방법이 있는지 궁금합니다. 지금은 그냥 filter 안에서 응답을 생성해주고 있는데 가독성 면에서 좋지 않은 것 같습니다,,, 더 좋은 방안이 있다면 알려주세요! :eyes:
- 또한 access token 재발급 로직에서 refresh token을 헤더와 바디 중 어디에 담아 보내는 것이 좋을지 궁금합니다!  :raising_hand:
- 지금은 tokenRepository에서 refresh token를 찾지 못했을 때 not found 오류를 주고 있는데 인증 정보가 만료된 것이니 401 401 Unauthorized를 반환하는 것이 맞는지 헷갈립니다.  :raised_hand:

## API 명세서 :notebook_with_decorative_cover:
https://regular-cow-aa9.notion.site/6-API-48e45cca667549fe8ed63af375853723?pvs=4
실제 동작과정은 api 명세서 안에 담았습니다!