### PR TITLE
Clone coding#3 클론 코딩 과제 3

### DIFF
--- a/cloneCoding/.idea/workspace.xml
+++ b/cloneCoding/.idea/workspace.xml
@@ -5,32 +5,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3da53616-7c84-45f6-8898-681b4f368249" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/GlobalExceptionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/ErrorMessage.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/ErrorResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/SuccessStatusResponse.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/config/JpaAuditingConfig.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/controller/HeartController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/BaseTimeEntity.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/Heart.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/TransactionPlace.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/exception/BusinessException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/exception/DuplicateLikeException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/exception/NotFoundException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/repository/HeartRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/HeartService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/ProductFindAllDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/exception/InvalidProductTypeException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/external/AwsConfig.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/external/S3Service.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/controller/MemberController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/controller/MemberController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/controller/ProductController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/controller/ProductController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/Product.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/Product.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/SellingProduct.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/SellingProduct.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/SharingProduct.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/domain/SharingProduct.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/repository/ProductRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/repository/ProductRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/MemberService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/MemberService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/ProductService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/ProductService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/MemberCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/MemberCreateDto.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/ProductCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/ProductCreateDto.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/SellingProductCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/SellingProductCreateDto.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/SharingProductCreateDto.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/sopt/cloneCoding/service/dto/SharingProductCreateDto.java" afterDir="false" />
@@ -104,27 +88,27 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Gradle.Build cloneCoding.executor": "Run",
-    "RequestMappingsPanelOrder0": "0",
-    "RequestMappingsPanelOrder1": "1",
-    "RequestMappingsPanelWidth0": "75",
-    "RequestMappingsPanelWidth1": "75",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "Spring Boot.CloneCodingApplication.executor": "Run",
-    "git-widget-placeholder": "main",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/Users/parks/Documents/GitHub/elive7/cloneCoding",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Gradle.Build cloneCoding.executor&quot;: &quot;Run&quot;,
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;Spring Boot.CloneCodingApplication.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;cloneCoding#3&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/parks/Documents/GitHub/elive7/cloneCoding&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager">
     <configuration default="true" type="JetRunConfigurationType">
       <method v="2">
@@ -164,6 +148,11 @@
       <workItem from="1713339127970" duration="34000" />
       <workItem from="1713339172784" duration="3687000" />
       <workItem from="1716613576799" duration="28000" />
+      <workItem from="1717126971380" duration="19000" />
+      <workItem from="1717139651870" duration="73000" />
+      <workItem from="1717155525234" duration="406000" />
+      <workItem from="1717155945586" duration="4716000" />
+      <workItem from="1717295008030" duration="6871000" />
     </task>
     <servers />
   </component>

--- a/cloneCoding/build.gradle
+++ b/cloneCoding/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	testImplementation 'io.rest-assured:rest-assured'
+
+	//Multipart file
+	implementation("software.amazon.awssdk:bom:2.21.0")
+	implementation("software.amazon.awssdk:s3:2.21.0")
 }
 
 tasks.named('test') {

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java
@@ -11,7 +11,6 @@ public enum SuccessMessage {
     PRODUCT_CREATE_SUCCESS(HttpStatus.CREATED.value(), "상품 등록이 완료되었습니다."),
     LIKE_CREATE_SUCCESS(HttpStatus.CREATED.value(), "좋아요가 추가되었습니다."),
     RRODUCT_GET_SUCCESS(HttpStatus.OK.value(),"상품 목록 조회가 완료되었습니다."),
-    PRODUCT_DELETE_SUCCESS(HttpStatus.OK.value(), "상품 삭제가 완료되었습니다.")
     ;
     private final int status;
     private final String message;

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/common/dto/SuccessMessage.java
@@ -10,7 +10,8 @@ public enum SuccessMessage {
     MEMBER_CREATE_SUCCESS(HttpStatus.CREATED.value(), "멤버 등록이 완료되었습니다."),
     PRODUCT_CREATE_SUCCESS(HttpStatus.CREATED.value(), "상품 등록이 완료되었습니다."),
     LIKE_CREATE_SUCCESS(HttpStatus.CREATED.value(), "좋아요가 추가되었습니다."),
-    RRODUCT_GET_SUCCESS(HttpStatus.OK.value(),"상품 목록 조회가 완료되었습니다.")
+    RRODUCT_GET_SUCCESS(HttpStatus.OK.value(),"상품 목록 조회가 완료되었습니다."),
+    PRODUCT_DELETE_SUCCESS(HttpStatus.OK.value(), "상품 삭제가 완료되었습니다.")
     ;
     private final int status;
     private final String message;

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,7 +34,7 @@ public class ProductController {
 
     @PostMapping("/selling")
     public ResponseEntity<SuccessStatusResponse> createSellingProduct(
-            @RequestBody SellingProductCreateDto sellingProductCreateDto
+            @ModelAttribute SellingProductCreateDto sellingProductCreateDto
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("Location", productService.createSellingProduct(sellingProductCreateDto))
@@ -41,7 +43,7 @@ public class ProductController {
 
     @PostMapping("/sharing")
     public ResponseEntity<SuccessStatusResponse> createSharingProduct(
-            @RequestBody SharingProductCreateDto sharingProductCreateDto
+            @ModelAttribute SharingProductCreateDto sharingProductCreateDto
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("Location", productService.createSharingProduct(sharingProductCreateDto))
@@ -56,6 +58,15 @@ public class ProductController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.RRODUCT_GET_SUCCESS,
                         productService.findProductByPlace(transactionPlace, pageable)));
+    }
+
+    @DeleteMapping("/{productId}")
+    public  ResponseEntity<SuccessStatusResponse> deleteProduct(
+            @PathVariable Long productId
+    ) {
+        productService.deleteProduct(productId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.PRODUCT_DELETE_SUCCESS));
     }
 
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java
@@ -61,12 +61,9 @@ public class ProductController {
     }
 
     @DeleteMapping("/{productId}")
-    public  ResponseEntity<SuccessStatusResponse> deleteProduct(
-            @PathVariable Long productId
-    ) {
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
         productService.deleteProduct(productId);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(SuccessStatusResponse.of(SuccessMessage.PRODUCT_DELETE_SUCCESS));
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/Product.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/Product.java
@@ -1,5 +1,6 @@
 package org.sopt.cloneCoding.domain;
 
+import jakarta.annotation.Nullable;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -36,10 +37,20 @@ public class Product extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     private TransactionPlace transactionPlace;
 
+    private String imageUrl;
+
     public Product(String title, Member seller, String description, TransactionPlace transactionPlace) {
         this.title = title;
         this.seller = seller;
         this.description = description;
         this.transactionPlace = transactionPlace;
+    }
+
+    public Product(String title, Member seller, String description, TransactionPlace transactionPlace,String imageUrl) {
+        this.title = title;
+        this.seller = seller;
+        this.description = description;
+        this.transactionPlace = transactionPlace;
+        this.imageUrl = imageUrl;
     }
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/Product.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/Product.java
@@ -39,12 +39,6 @@ public class Product extends BaseTimeEntity{
 
     private String imageUrl;
 
-    public Product(String title, Member seller, String description, TransactionPlace transactionPlace) {
-        this.title = title;
-        this.seller = seller;
-        this.description = description;
-        this.transactionPlace = transactionPlace;
-    }
 
     public Product(String title, Member seller, String description, TransactionPlace transactionPlace,String imageUrl) {
         this.title = title;

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SellingProduct.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SellingProduct.java
@@ -15,8 +15,8 @@ public class SellingProduct extends Product {
     private boolean negotiable;
 
     public SellingProduct(String title, Member seller, Double price, String description, TransactionPlace transactionPlace,
-                          boolean negotiable) {
-        super(title, seller, description, transactionPlace);
+                          boolean negotiable, String imageUrl) {
+        super(title, seller, description, transactionPlace, imageUrl);
         this.price = price;
         this.negotiable = negotiable;
     }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SharingProduct.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SharingProduct.java
@@ -13,8 +13,8 @@ public class SharingProduct extends Product {
     private Boolean sharingEvent;
 
     public SharingProduct(String title, Member seller, String description, TransactionPlace transactionPlace,
-                          Boolean sharingEvent) {
-        super(title, seller, description, transactionPlace);
+                          Boolean sharingEvent, String imageUrl) {
+        super(title, seller, description, transactionPlace, imageUrl);
         this.sharingEvent = sharingEvent;
     }
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/exception/InvalidProductTypeException.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/exception/InvalidProductTypeException.java
@@ -1,0 +1,4 @@
+package org.sopt.cloneCoding.exception;
+
+public class InvalidProductTypeException {
+}

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/external/AwsConfig.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/external/AwsConfig.java
@@ -1,0 +1,48 @@
+package org.sopt.cloneCoding.external;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String regionString;
+
+    public AwsConfig(@Value("${aws-property.access-key}") final String accessKey,
+                     @Value("${aws-property.secret-key}") final String secretKey,
+                     @Value("${aws-property.aws-region}") final String regionString) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.regionString = regionString;
+    }
+
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(regionString);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/external/S3Service.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/external/S3Service.java
@@ -1,0 +1,79 @@
+package org.sopt.cloneCoding.external;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+public class S3Service {
+
+    private final String bucketName;
+    private final AwsConfig awsConfig;
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+
+    public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AwsConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        final String key = directoryPath + generateImageFileName();
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return key;
+    }
+
+    public void deleteImage(String key) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
+                builder.bucket(bucketName)
+                        .key(key)
+                        .build()
+        );
+    }
+
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new RuntimeException("이미지 확장자는 jpg, png, webp만 가능합니다.");
+        }
+    }
+
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new RuntimeException("이미지 사이즈는 5MB를 넘을 수 없습니다.");
+        }
+    }
+
+}

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java
@@ -1,6 +1,7 @@
 package org.sopt.cloneCoding.service;
 
 import jakarta.transaction.Transactional;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.cloneCoding.common.dto.ErrorMessage;
@@ -11,6 +12,7 @@ import org.sopt.cloneCoding.domain.SellingProduct;
 import org.sopt.cloneCoding.domain.SharingProduct;
 import org.sopt.cloneCoding.domain.TransactionPlace;
 import org.sopt.cloneCoding.exception.NotFoundException;
+import org.sopt.cloneCoding.external.S3Service;
 import org.sopt.cloneCoding.repository.ProductRepository;
 import org.sopt.cloneCoding.repository.SellingProcuctRepository;
 import org.sopt.cloneCoding.repository.SharingProductRepository;
@@ -28,18 +30,39 @@ public class ProductService {
     private final SellingProcuctRepository sellingProductRepository;
     private final SharingProductRepository sharingProductRepository;
     private final MemberService memberService;
+    private final S3Service s3Service;
+    private static final String PRODUCT_S3_UPLOAD_FOLER = "product/";
 
     @Transactional
     public String createSellingProduct(SellingProductCreateDto sellingProductCreateDto) {
         Member member = memberService.findMemberById(sellingProductCreateDto.getSellerId());
-        SellingProduct sellingProduct = SellingProduct.builder()
-                .title(sellingProductCreateDto.getTitle())
-                .seller(member)
-                .price(sellingProductCreateDto.getPrice())
-                .description(sellingProductCreateDto.getDescription())
-                .transactionPlace(sellingProductCreateDto.getTransactionPlace())
-                .negotiable(sellingProductCreateDto.getNegotiable())
-                .build();
+        SellingProduct sellingProduct;
+        if (sellingProductCreateDto.getImage() == null){
+            sellingProduct = SellingProduct.builder()
+                    .title(sellingProductCreateDto.getTitle())
+                    .seller(member)
+                    .price(sellingProductCreateDto.getPrice())
+                    .description(sellingProductCreateDto.getDescription())
+                    .transactionPlace(sellingProductCreateDto.getTransactionPlace())
+                    .negotiable(sellingProductCreateDto.getNegotiable())
+                    .build();
+        }
+        else {
+            try {
+                String imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sellingProductCreateDto.getImage());
+                sellingProduct = SellingProduct.builder()
+                        .title(sellingProductCreateDto.getTitle())
+                        .seller(member)
+                        .price(sellingProductCreateDto.getPrice())
+                        .description(sellingProductCreateDto.getDescription())
+                        .transactionPlace(sellingProductCreateDto.getTransactionPlace())
+                        .negotiable(sellingProductCreateDto.getNegotiable())
+                        .imageUrl(imageUrl)
+                        .build();
+            } catch (RuntimeException | IOException e){
+                throw new RuntimeException((e.getMessage()));
+            }
+        }
         sellingProductRepository.save(sellingProduct);
         return sellingProduct.getId().toString();
     }
@@ -47,13 +70,31 @@ public class ProductService {
     @Transactional
     public String createSharingProduct(SharingProductCreateDto sharingProductCreateDto) {
         Member member = memberService.findMemberById(sharingProductCreateDto.getSellerId());
-        SharingProduct sharingProduct = SharingProduct.builder()
-                .title(sharingProductCreateDto.getTitle())
-                .seller(member)
-                .description(sharingProductCreateDto.getDescription())
-                .transactionPlace(sharingProductCreateDto.getTransactionPlace())
-                .sharingEvent(sharingProductCreateDto.getSharingEvent())
-                .build();
+        SharingProduct sharingProduct;
+        if (sharingProductCreateDto.getImage() == null){
+            sharingProduct = SharingProduct.builder()
+                    .title(sharingProductCreateDto.getTitle())
+                    .seller(member)
+                    .description(sharingProductCreateDto.getDescription())
+                    .transactionPlace(sharingProductCreateDto.getTransactionPlace())
+                    .sharingEvent(sharingProductCreateDto.getSharingEvent())
+                    .build();
+        }
+        else {
+            try {
+                String imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sharingProductCreateDto.getImage());
+                sharingProduct = SharingProduct.builder()
+                        .title(sharingProductCreateDto.getTitle())
+                        .seller(member)
+                        .description(sharingProductCreateDto.getDescription())
+                        .transactionPlace(sharingProductCreateDto.getTransactionPlace())
+                        .sharingEvent(sharingProductCreateDto.getSharingEvent())
+                        .imageUrl(imageUrl)
+                        .build();
+            } catch (RuntimeException | IOException e){
+                throw new RuntimeException((e.getMessage()));
+            }
+        }
         sharingProductRepository.save(sharingProduct);
         return sharingProduct.getId().toString();
     }
@@ -66,5 +107,31 @@ public class ProductService {
         return productRepository.findById(productId).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.PRODUCT_NOT_FOUND)
         );
+    }
+
+    public void deleteProduct(Long productId){
+        Product product = findProductById(productId);
+        if (product instanceof SellingProduct){
+            try {
+                SellingProduct sellingProduct = (SellingProduct) product;
+                if (sellingProduct.getImageUrl() != null){
+                    s3Service.deleteImage(sellingProduct.getImageUrl());
+                }
+                sellingProductRepository.delete(sellingProduct);
+            } catch (RuntimeException | IOException e){
+                throw new RuntimeException((e.getMessage()));
+            }
+        }
+        else if (product instanceof SharingProduct){
+            try {
+                SharingProduct sharingProduct = (SharingProduct) product;
+                if (sharingProduct.getImageUrl() != null){
+                    s3Service.deleteImage(sharingProduct.getImageUrl());
+                }
+                sharingProductRepository.delete(sharingProduct);
+            } catch (RuntimeException | IOException e){
+                throw new RuntimeException((e.getMessage()));
+            }
+        }
     }
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java
@@ -36,54 +36,36 @@ public class ProductService {
     @Transactional
     public String createSellingProduct(SellingProductCreateDto sellingProductCreateDto) {
         Member member = memberService.findMemberById(sellingProductCreateDto.getSellerId());
-        SellingProduct sellingProduct;
-        if (sellingProductCreateDto.getImage() == null){
-            sellingProduct = SellingProduct.builder()
+        try {
+            String imageUrl = null;
+            if (sellingProductCreateDto.getImage() != null){
+                imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sellingProductCreateDto.getImage());
+            }
+            SellingProduct sellingProduct = SellingProduct.builder()
                     .title(sellingProductCreateDto.getTitle())
                     .seller(member)
                     .price(sellingProductCreateDto.getPrice())
                     .description(sellingProductCreateDto.getDescription())
                     .transactionPlace(sellingProductCreateDto.getTransactionPlace())
                     .negotiable(sellingProductCreateDto.getNegotiable())
+                    .imageUrl(imageUrl)
                     .build();
+            sellingProductRepository.save(sellingProduct);
+            return sellingProduct.getId().toString();
+        } catch (RuntimeException | IOException e) {
+            throw new RuntimeException((e.getMessage()));
         }
-        else {
-            try {
-                String imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sellingProductCreateDto.getImage());
-                sellingProduct = SellingProduct.builder()
-                        .title(sellingProductCreateDto.getTitle())
-                        .seller(member)
-                        .price(sellingProductCreateDto.getPrice())
-                        .description(sellingProductCreateDto.getDescription())
-                        .transactionPlace(sellingProductCreateDto.getTransactionPlace())
-                        .negotiable(sellingProductCreateDto.getNegotiable())
-                        .imageUrl(imageUrl)
-                        .build();
-            } catch (RuntimeException | IOException e){
-                throw new RuntimeException((e.getMessage()));
-            }
-        }
-        sellingProductRepository.save(sellingProduct);
-        return sellingProduct.getId().toString();
     }
 
     @Transactional
     public String createSharingProduct(SharingProductCreateDto sharingProductCreateDto) {
         Member member = memberService.findMemberById(sharingProductCreateDto.getSellerId());
-        SharingProduct sharingProduct;
-        if (sharingProductCreateDto.getImage() == null){
-            sharingProduct = SharingProduct.builder()
-                    .title(sharingProductCreateDto.getTitle())
-                    .seller(member)
-                    .description(sharingProductCreateDto.getDescription())
-                    .transactionPlace(sharingProductCreateDto.getTransactionPlace())
-                    .sharingEvent(sharingProductCreateDto.getSharingEvent())
-                    .build();
-        }
-        else {
-            try {
-                String imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sharingProductCreateDto.getImage());
-                sharingProduct = SharingProduct.builder()
+        try{
+                String imageUrl = null;
+                if (sharingProductCreateDto.getImage() != null){
+                    imageUrl = s3Service.uploadImage(PRODUCT_S3_UPLOAD_FOLER, sharingProductCreateDto.getImage());
+                }
+                SharingProduct sharingProduct = SharingProduct.builder()
                         .title(sharingProductCreateDto.getTitle())
                         .seller(member)
                         .description(sharingProductCreateDto.getDescription())
@@ -91,12 +73,11 @@ public class ProductService {
                         .sharingEvent(sharingProductCreateDto.getSharingEvent())
                         .imageUrl(imageUrl)
                         .build();
-            } catch (RuntimeException | IOException e){
-                throw new RuntimeException((e.getMessage()));
-            }
+            sharingProductRepository.save(sharingProduct);
+            return sharingProduct.getId().toString();
+        } catch (RuntimeException | IOException e) {
+            throw new RuntimeException((e.getMessage()));
         }
-        sharingProductRepository.save(sharingProduct);
-        return sharingProduct.getId().toString();
     }
 
     public Slice<ProductFindAllDto> findProductByPlace(TransactionPlace transactionPlace, Pageable pageable){

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/MemberCreateDto.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/MemberCreateDto.java
@@ -1,4 +1,6 @@
 package org.sopt.cloneCoding.service.dto;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record MemberCreateDto(String userId, String name, int age) {
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/ProductCreateDto.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/ProductCreateDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.sopt.cloneCoding.domain.Member;
 import org.sopt.cloneCoding.domain.TransactionPlace;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
@@ -13,4 +14,5 @@ public class ProductCreateDto {
     private Long sellerId;
     private String description;
     private TransactionPlace transactionPlace;
+    private MultipartFile image;
 }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SellingProductCreateDto.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SellingProductCreateDto.java
@@ -2,6 +2,7 @@ package org.sopt.cloneCoding.service.dto;
 
 import lombok.Getter;
 import org.sopt.cloneCoding.domain.TransactionPlace;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 public class SellingProductCreateDto extends ProductCreateDto {
@@ -10,8 +11,9 @@ public class SellingProductCreateDto extends ProductCreateDto {
 
     public SellingProductCreateDto(String title, Long sellerId, Double price, String description,
                                    TransactionPlace transactionPlace,
-                                   Boolean negotiable) {
-        super(title, sellerId, description, transactionPlace);
+                                   Boolean negotiable,
+                                   MultipartFile image) {
+        super(title, sellerId, description, transactionPlace, image);
         this.price = price;
         this.negotiable = negotiable;
     }

--- a/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SharingProductCreateDto.java
+++ b/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SharingProductCreateDto.java
@@ -2,6 +2,7 @@ package org.sopt.cloneCoding.service.dto;
 
 import lombok.Getter;
 import org.sopt.cloneCoding.domain.TransactionPlace;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 public class SharingProductCreateDto extends ProductCreateDto {
@@ -9,8 +10,9 @@ public class SharingProductCreateDto extends ProductCreateDto {
 
     public SharingProductCreateDto(String title, Long sellerId, String description,
                                    TransactionPlace transactionPlace,
-                                   Boolean sharingEvent) {
-        super(title, sellerId, description, transactionPlace);
+                                   Boolean sharingEvent,
+                                   MultipartFile image) {
+        super(title, sellerId, description, transactionPlace, image);
         this.sharingEvent = sharingEvent;
     }
 }


### PR DESCRIPTION
- closes #13 
## 이 주의 과제 :closed_book:

<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
### 사진 업로드를 포함한 상품 등록 api
#### AwsConfig
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/external/AwsConfig.java#L10-L48

#### S3Service
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/external/S3Service.java#L15-L79
aws의 s3 서비스를 활용하여 사진을 업로드 및 삭제할 수 있도록 위와 같이 코드를 작성해주었습니다.

#### ‎Product
https://github.com/NOW-SOPT-SERVER/elive7/blob/5575b7baff995b820631ed6b8998f1570abc7512/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/Product.java#L40-L49
#### SellingProduct
https://github.com/NOW-SOPT-SERVER/elive7/blob/5575b7baff995b820631ed6b8998f1570abc7512/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SellingProduct.java#L17-L21
#### SharingProduct
https://github.com/NOW-SOPT-SERVER/elive7/blob/5575b7baff995b820631ed6b8998f1570abc7512/cloneCoding/src/main/java/org/sopt/cloneCoding/domain/SharingProduct.java#L15-L18
SellingProdcuct와 SharingProduct의 부모 클래스인 Product에 imageUrl 속성을 추가하고, 이에 맞게 Product와 SellingProdcuct, SharingProduct의 생성자도 수정했습니다.

#### ProductController
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java#L35-L51
상품 등록 정보를 request body가 아닌 ModelAttribute로 받도록 수정했습니다.

#### ProductCreateDto
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/ProductCreateDto.java#L10-L18

#### SellingProductCreateDto
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SellingProductCreateDto.java#L7-L20
#### SharingProductCreateDto
https://github.com/NOW-SOPT-SERVER/elive7/blob/cb8b013d8b442f12beb6e701acd9283914fc25d3/cloneCoding/src/main/java/org/sopt/cloneCoding/service/dto/SharingProductCreateDto.java#L7-L18

ProductCreateDto에 MultipartFile image 속성을 추가하고 그게 맞게 SellingProductCreateDto와 SharingProductCreateDto도 수정해주었습니다.

#### ProductService
https://github.com/NOW-SOPT-SERVER/elive7/blob/3a6387b843e391cae4945f46734390e7f57d9122/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java#L36-L81
sellingProductCreateDto.getImage()를 확인해 null이 아니라면, s3에 해당 이미지를 업로드하고, sellingProduct에 imageUrl를 세팅하여 저장하고, null이라면 sellingProduct에 imageUrl로 null을 세팅하여 저장해주었습니다. sharingProduct 등록도 같은 로직을 적용했습니다.

### 사진 업로드를 포함한 상품 삭제 api
#### ProductController
https://github.com/NOW-SOPT-SERVER/elive7/blob/66aca06b0849742d7b789c4d0cfb8f6c97c94544/cloneCoding/src/main/java/org/sopt/cloneCoding/controller/ProductController.java#L63-L67
‎PathVariable로 productId를 받아서 상품을 삭제하는 로직을 실행할 수 있도록 다음과 같이 코드를 작성해주었습니다. 삭제시 noContent 204를 반환하도록 해주었습니다.

#### ProductService
https://github.com/NOW-SOPT-SERVER/elive7/blob/66aca06b0849742d7b789c4d0cfb8f6c97c94544/cloneCoding/src/main/java/org/sopt/cloneCoding/service/ProductService.java#L93-L117
해당 product가 SellingProduct/SharingProduct 중 어느 타입인지 확인해, 맞는 타입으로 다운캐스팅 한 후, imageUrl에 값이 있다면 s3의 사진을 지우는 로직을 수행한 후 실제 판매상품/나눔상품도 삭제하는 로직을 작성했습니다.


## 요구사항 분석 :orange_book:

<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->

- localhost:8080/api/v1/product/selling로 title, sellerId, price, description, transactionPlace, negotiable, image 등의 정보를 바탕으로 판매 상품을 등록할 수 있습니다. 
- localhost:8080/api/v1/product/sharing로 title, sellerId, description, transactionPlace, sharingEvent, image 등의 정도를 바탕으로 나눔 상품을 등록할 수 있습니다.
- 판매 상품과 나눔 상품 모두 이미지를 넣지 않아도 상품 등록이 가능합니다.
- localhost:8080/api/v1/product/:productId로 id에 해당하는 상품을 삭제할 수 있습니다.


## 구현 고민 사항 :green_book:

<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->
- 이미지가 있을 때나 없을 때 모두 상품이 등록/삭제될 수 있도록 코드를 작성했습니다.
- 이 과정에서 최대한 코드의 중복을 줄이고자 노력했습니다.

## 질문있어요! :blue_book:

<!-- 구현하면서 코드리뷰조원이나 명예 OB 분들께 하고 싶었던 질문이 있다면 (필요시)코드 좌표와 함께 **자세히** 적어주세요! -->
- 현재는 나눔 상품과 판매 상품 delete를 같은 url 하나에서 처리하고 있습니다. 이때, 나눔 상품과 판매 상품의 delete 로직을 나눠서 작성하는 것이 좋을지, 따로 작성하는 것이 좋을지 궁금합니다.
- 이미지 유무에 상관없이 상품을 등록하는 로직을 더 좋은 방식으로 작성할 수 있을지 궁금합니다.

## API 명세서 :notebook_with_decorative_cover:
https://regular-cow-aa9.notion.site/6-API-4dd4004677a04e259e2658a8d3988a24?pvs=4